### PR TITLE
Add Jest tests for util and component

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/__tests__/ResultsTable.test.jsx
+++ b/__tests__/ResultsTable.test.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ResultsTable } from '../src/ResultsTable.jsx';
+
+describe('ResultsTable', () => {
+  test('displays computed WER', () => {
+    const texts = [{ text: 'hello world' }];
+    const transcripts = [{ aIndex: 0, text: 'hello there' }];
+    render(<ResultsTable texts={texts} transcripts={transcripts} />);
+    const cell = screen.getByText('0.50');
+    expect(cell).toBeInTheDocument();
+  });
+});

--- a/__tests__/wordErrorRate.test.js
+++ b/__tests__/wordErrorRate.test.js
@@ -1,0 +1,11 @@
+import { wordErrorRate } from '../src/wordErrorRate.js';
+
+describe('wordErrorRate', () => {
+  test('identical sentences have WER 0', () => {
+    expect(wordErrorRate('hello world', 'hello world')).toBe('0.00');
+  });
+
+  test('single substitution', () => {
+    expect(wordErrorRate('hello world', 'hello there')).toBe('0.50');
+  });
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "ai-ai-ai",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.23.0",
+    "@babel/preset-react": "^7.22.15",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^14.1.2",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.2",
+    "jsdom": "^23.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "transform": {
+      "^.+\\.[tj]sx?$": "babel-jest"
+    },
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest.setup.js"
+    ]
+  }
+}

--- a/src/ResultsTable.jsx
+++ b/src/ResultsTable.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { wordErrorRate } from './wordErrorRate.js';
+
+export function ResultsTable({ texts = [], transcripts = [] }) {
+  const rows = transcripts.map((t, i) => {
+    const txt = texts[t.aIndex];
+    const wer = wordErrorRate(txt.text, t.text);
+    return { i: i + 1, original: txt.text, transcription: t.text, wer };
+  });
+
+  return (
+    <table data-testid="results-table">
+      <tbody>
+        {rows.map(r => (
+          <tr key={r.i}>
+            <td>{r.i}</td>
+            <td>{r.original}</td>
+            <td>{r.transcription}</td>
+            <td>{r.wer}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/wordErrorRate.js
+++ b/src/wordErrorRate.js
@@ -1,0 +1,18 @@
+export function wordErrorRate(ref, hyp) {
+  const r = ref.split(/\s+/);
+  const h = hyp.split(/\s+/);
+  const dp = Array.from({ length: r.length + 1 }, () => Array(h.length + 1).fill(0));
+  for (let i = 0; i <= r.length; i++) dp[i][0] = i;
+  for (let j = 0; j <= h.length; j++) dp[0][j] = j;
+  for (let i = 1; i <= r.length; i++) {
+    for (let j = 1; j <= h.length; j++) {
+      const cost = r[i - 1] === h[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost
+      );
+    }
+  }
+  return (dp[r.length][h.length] / r.length).toFixed(2);
+}


### PR DESCRIPTION
## Summary
- add Jest configuration with Babel presets
- provide wordErrorRate utility module
- provide a simple ResultsTable component
- test the utility function and the component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854806f1fa483248f877778a60c1a97