### PR TITLE
Add editing, uploads and diff view

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ npm test
 - Synthesize text to audio using the browser Speech Synthesis API (or mock blobs).
 - Transcribe audio back to text (mock mode copies the original text).
 - Compute the Word Error Rate (WER) between the generated text and transcription.
+- Visual diff view highlighting transcription errors.
+- Users can add their own texts, edit generated ones and upload audio files.
+- Export results as JSON or CSV and clear all stored data.
 - Results are persisted in browser local storage.
 
 This is not a production-ready system but demonstrates the flow described in the specification.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { wordErrorRate } from './wordErrorRate';
+import { diffWordsHtml } from './diffWords';
 
 function useStoredState(key, initial) {
   const [state, setState] = useState(() => {
@@ -17,13 +18,17 @@ export default function App() {
   const [texts, setTexts] = useStoredState('texts', []);
   const [audios, setAudios] = useStoredState('audios', []);
   const [transcripts, setTranscripts] = useStoredState('transcripts', []);
+  const [newText, setNewText] = useState('');
+  const [status, setStatus] = useState('');
 
   const mockMode = !apiKeys.openai;
 
   const generateText = async () => {
+    setStatus('Generating text...');
     if (mockMode) {
       const mock = `Näidis lause ${texts.length + 1} numbriga ${Math.floor(Math.random()*100)}`;
       setTexts([...texts, { provider: 'mock', text: mock }]);
+      setStatus('');
       return;
     }
     const prompt = 'Loo keeruline lühike eestikeelne tekst, mis sisaldab numbreid ja lühendeid.';
@@ -40,40 +45,89 @@ export default function App() {
     }).then(r => r.json());
     const text = res.choices?.[0]?.message?.content?.trim();
     if (text) setTexts([...texts, { provider: 'openai', text }]);
+    setStatus('');
   };
 
   const synthesize = async (index) => {
     const txt = texts[index];
     if (!txt) return;
+    setStatus('Synthesizing...');
     if (mockMode) {
       const blob = new Blob([txt.text], { type: 'audio/plain' });
       const url = URL.createObjectURL(blob);
       setAudios([...audios, { index, provider: 'mock', url }]);
+      setStatus('');
       return;
     }
     const utter = new SpeechSynthesisUtterance(txt.text);
     speechSynthesis.speak(utter);
     const url = '';
     setAudios([...audios, { index, provider: 'speechSynthesis', url }]);
+    setStatus('');
+  };
+
+  const uploadAudio = (index, file) => {
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    setAudios([...audios, { index, provider: 'upload', url }]);
   };
 
   const transcribe = async (aIndex) => {
     const audio = audios[aIndex];
     if (!audio) return;
+    setStatus('Transcribing...');
     if (mockMode) {
       const transcript = texts[audio.index]?.text || '';
       setTranscripts([...transcripts, { aIndex, provider: 'mock', text: transcript }]);
+      setStatus('');
       return;
     }
     const transcript = texts[audio.index]?.text || '';
     setTranscripts([...transcripts, { aIndex, provider: 'copy', text: transcript }]);
+    setStatus('');
+  };
+
+  const updateText = (index, text) => {
+    setTexts(texts.map((t, i) => (i === index ? { ...t, text } : t)));
+  };
+
+  const addText = () => {
+    if (!newText.trim()) return;
+    setTexts([...texts, { provider: 'user', text: newText.trim() }]);
+    setNewText('');
+  };
+
+  const clearData = () => {
+    localStorage.clear();
+    setTexts([]); setAudios([]); setTranscripts([]);
+  };
+
+  const exportJSON = () => {
+    const blob = new Blob([JSON.stringify(rows, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'results.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportCSV = () => {
+    const header = 'index,original,transcription,wer\n';
+    const lines = rows.map(r => `${r.i},"${r.original}","${r.transcription}",${r.wer}`).join('\n');
+    const blob = new Blob([header + lines], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'results.csv';
+    a.click();
+    URL.revokeObjectURL(url);
   };
 
   const rows = transcripts.map((t, i) => {
     const audio = audios[t.aIndex];
     const txt = texts[audio.index];
     const wer = wordErrorRate(txt.text, t.text);
-    return { i: i + 1, original: txt.text, transcription: t.text, wer };
+    const diff = diffWordsHtml(txt.text, t.text);
+    return { i: i + 1, original: txt.text, transcription: t.text, wer, diff };
   });
 
   return (
@@ -89,9 +143,17 @@ export default function App() {
       {mockMode && <p style={{color:'red'}}>Mock mode active: no API key</p>}
       <h2>Text Generation</h2>
       <button onClick={generateText}>Generate Sample Text</button>
+      <div>
+        <textarea value={newText} onChange={e => setNewText(e.target.value)} placeholder="Add custom text" />
+        <button onClick={addText}>Add Text</button>
+      </div>
       <ul>
         {texts.map((t, i) => (
-          <li key={i}>{t.text} <button onClick={() => synthesize(i)}>Synthesize</button></li>
+          <li key={i}>
+            <textarea value={t.text} onChange={e => updateText(i, e.target.value)} />
+            <button onClick={() => synthesize(i)}>Synthesize</button>
+            <input type="file" accept="audio/*" onChange={e => uploadAudio(i, e.target.files[0])} />
+          </li>
         ))}
       </ul>
       <h2>Generated Audio</h2>
@@ -105,9 +167,12 @@ export default function App() {
         ))}
       </ul>
       <h2>Results</h2>
+      <button onClick={exportJSON}>Export JSON</button>
+      <button onClick={exportCSV}>Export CSV</button>
+      <button onClick={clearData}>Clear Data</button>
       <table>
         <thead>
-          <tr><th>#</th><th>Original Text</th><th>Transcription</th><th>WER</th></tr>
+          <tr><th>#</th><th>Original Text</th><th>Transcription</th><th>WER</th><th>Diff</th></tr>
         </thead>
         <tbody>
           {rows.map(r => (
@@ -116,10 +181,12 @@ export default function App() {
               <td>{r.original}</td>
               <td>{r.transcription}</td>
               <td>{r.wer}</td>
+              <td dangerouslySetInnerHTML={{__html:r.diff}}></td>
             </tr>
           ))}
         </tbody>
       </table>
+      {status && <p>{status}</p>}
     </div>
   );
 }

--- a/src/diffWords.js
+++ b/src/diffWords.js
@@ -1,0 +1,35 @@
+export function diffWords(ref, hyp) {
+  const r = ref.split(/\s+/);
+  const h = hyp.split(/\s+/);
+  const dp = Array.from({ length: r.length + 1 }, () => Array(h.length + 1).fill(0));
+  for (let i = 1; i <= r.length; i++) {
+    for (let j = 1; j <= h.length; j++) {
+      if (r[i - 1] === h[j - 1]) dp[i][j] = dp[i - 1][j - 1] + 1;
+      else dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+  const diff = [];
+  let i = r.length, j = h.length;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && r[i - 1] === h[j - 1]) {
+      diff.unshift({ type: 'equal', word: r[i - 1] });
+      i--; j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      diff.unshift({ type: 'insert', word: h[j - 1] });
+      j--;
+    } else {
+      diff.unshift({ type: 'delete', word: r[i - 1] });
+      i--;
+    }
+  }
+  return diff;
+}
+
+export function diffWordsHtml(ref, hyp) {
+  return diffWords(ref, hyp)
+    .map(d => {
+      if (d.type === 'equal') return d.word;
+      return `<span class="${d.type}">${d.word}</span>`;
+    })
+    .join(' ');
+}

--- a/src/diffWords.test.js
+++ b/src/diffWords.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { diffWords } from './diffWords';
+
+describe('diffWords', () => {
+  it('marks identical words as equal', () => {
+    const diff = diffWords('a b', 'a b');
+    expect(diff).toEqual([
+      {type:'equal', word:'a'},
+      {type:'equal', word:'b'}
+    ]);
+  });
+  it('detects insert and delete', () => {
+    const diff = diffWords('a b', 'a x b');
+    expect(diff).toEqual([
+      {type:'equal', word:'a'},
+      {type:'insert', word:'x'},
+      {type:'equal', word:'b'}
+    ]);
+  });
+});

--- a/src/style.css
+++ b/src/style.css
@@ -2,3 +2,5 @@ body { font-family: sans-serif; margin: 0; padding: 1rem; }
 textarea { width: 100%; height: 6rem; }
 table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
 th, td { border: 1px solid #ccc; padding: 0.25rem; }
+.insert { background-color: #dfd; }
+.delete { background-color: #fdd; text-decoration: line-through; }


### PR DESCRIPTION
## Summary
- implement word diff algorithm
- expose diff view in results table
- allow manual text entry and editing
- upload audio files as inputs
- export JSON or CSV, clear local storage
- show simple status messages
- document new features

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685489a5bfe8832499c2ba41274ddb6b