### PR TITLE
Fix blank page by using relative build paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Build static files with:
 npm run build
 ```
 
+This generates production files in the `dist` directory. Open
+`dist/index.html` in your browser to use the app without running the
+development server.
+
 To execute the unit tests run:
 
 ```bash

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './',
+});


### PR DESCRIPTION
## Summary
- configure Vite to use relative paths when building
- document how to open the built app

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68548b29a8048324be060b7632e27361