### PR TITLE
Add model selection fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ npm test
 
 ## Features
 
-- Generate Estonian texts via OpenAI API or a built‑in mock mode when no API key is provided.
+- Generate Estonian texts via OpenAI or Google APIs. A built‑in mock mode is used when no API keys are provided.
+- API keys and available models for each provider can be entered in the UI. Model lists are fetched from the APIs.
 - Synthesize text to audio using the browser Speech Synthesis API (or mock blobs).
 - Transcribe audio back to text (mock mode copies the original text).
 - Compute the Word Error Rate (WER) between the generated text and transcription.


### PR DESCRIPTION
## Summary
- enable OpenAI and Google API key inputs
- fetch model lists from both APIs
- allow choosing provider and model when generating text
- document new feature in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68548e104e9c8324976df2b423aac75d