### PR TITLE
Fix App.jsx fragment closure and add build test

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -346,6 +346,7 @@ export default function App() {
       </table>
       {status && <p>{status}</p>}
     </div>
+    </>
   );
 }
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { transform } from 'esbuild';
+import fs from 'fs';
+
+describe('App.jsx compilation', () => {
+  it('compiles without syntax errors', async () => {
+    const code = fs.readFileSync('src/App.jsx', 'utf8');
+    await expect(transform(code, { loader: 'jsx' })).resolves.toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- fix missing closing fragment in `src/App.jsx`
- add a vitest test to ensure `App.jsx` compiles without JSX errors

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685492f84c548324b6fcef440348def9