### PR TITLE
UI tables export improvements

### DIFF
--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -1,0 +1,37 @@
+export function rowsToJSON(rows, columns) {
+  const fields = columns.filter(c => c.field !== 'actions');
+  const data = rows.map(r => {
+    const obj = {};
+    for (const c of fields) obj[c.field] = r[c.field];
+    return obj;
+  });
+  return JSON.stringify(data, null, 2);
+}
+
+export function rowsToCSV(rows, columns) {
+  const fields = columns.filter(c => c.field !== 'actions');
+  const header = fields.map(f => f.headerName || f.field).join(',');
+  const lines = rows.map(r => fields.map(f => {
+    const val = r[f.field] == null ? '' : String(r[f.field]).replace(/"/g, '""');
+    return `"${val}"`;
+  }).join(',')).join('\n');
+  return header + '\n' + lines;
+}
+
+export function rowsToMarkdown(rows, columns) {
+  const fields = columns.filter(c => c.field !== 'actions');
+  const header = '|' + fields.map(f => f.headerName || f.field).join('|') + '|';
+  const separator = '|' + fields.map(() => '---').join('|') + '|';
+  const lines = rows.map(r => '|' + fields.map(f => String(r[f.field] ?? '').replace(/\|/g, '\\|')).join('|') + '|').join('\n');
+  return header + '\n' + separator + '\n' + lines;
+}
+
+export function download(content, type, filename) {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/exportUtils.test.js
+++ b/src/exportUtils.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { rowsToCSV, rowsToMarkdown } from './exportUtils.js';
+
+const columns = [
+  { field: 'a', headerName: 'A' },
+  { field: 'b', headerName: 'B' }
+];
+const rows = [
+  { a: 'x', b: 'y' },
+  { a: '1', b: '2' }
+];
+
+describe('export utils', () => {
+  it('converts rows to CSV', () => {
+    const csv = rowsToCSV(rows, columns).trim();
+    expect(csv).toBe('A,B\n"x","y"\n"1","2"');
+  });
+  it('converts rows to Markdown', () => {
+    const md = rowsToMarkdown(rows, columns).trim();
+    expect(md).toBe('|A|B|\n|---|---|\n|x|y|\n|1|2|');
+  });
+});


### PR DESCRIPTION
## Summary
- add export helper utilities and tests
- show tooltips with wrapping in tables
- filter out TTS prompts from text table
- add export buttons and horizontal dividers for all tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a07a9f5b48324ba43a40b5993ac52