### PR TITLE
Add playground icon and tweak UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import PlaygroundIcon from './PlaygroundIcon';
 import { wordErrorRate } from './wordErrorRate';
 import { diffWordsHtml } from './diffWords';
 import {
@@ -702,6 +703,7 @@ export default function App() {
     <>
       <AppBar position="fixed">
         <Toolbar>
+          <PlaygroundIcon sx={{ mr: 1 }} />
           <Typography variant="h6" sx={{ flexGrow: 1 }}>{t('appTitle')}</Typography>
           <Tabs value={view} onChange={(e, v) => setView(v)} textColor="inherit" indicatorColor="secondary">
             <Tab value="text" label={t('tabText')} />
@@ -776,7 +778,6 @@ export default function App() {
       )}
       {view === 'asr' && (
         <div style={{ padding: '1rem' }}>
-          <Typography variant="h6">{t('tabAsr')}</Typography>
           <Select multiple value={selectedAsrModels} onChange={e => setSelectedAsrModels(e.target.value)} fullWidth renderValue={s => s.join(', ')}>
             {asrModels.map(m => (
               <MenuItem key={m.id} value={m.id}>{m.name}</MenuItem>
@@ -797,7 +798,6 @@ export default function App() {
       )}
       {view === 'log' && (
         <div style={{ padding: '1rem' }}>
-          <Typography variant="h6">{t('tabLog')}</Typography>
           <Divider sx={{ my: 2 }} />
           <ExportButtons rows={logRows} columns={logColumns} name="logs" t={t} />
           <PersistedGrid
@@ -809,7 +809,6 @@ export default function App() {
       )}
       {view === 'config' && (
         <div style={{ padding: '1rem' }}>
-          <Typography variant="h6">{t('tabSettings')}</Typography>
           <TextField
             label={t('openaiKey')}
             type="password"

--- a/src/PlaygroundIcon.jsx
+++ b/src/PlaygroundIcon.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import SvgIcon from '@mui/material/SvgIcon';
+
+export default function PlaygroundIcon(props) {
+  return (
+    <SvgIcon {...props} viewBox="0 0 72 72">
+      <g id="line">
+        <line x1="24.8609" x2="18.5199" y1="37.751" y2="58.3026" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" />
+        <line x1="16.03" x2="7.3724" y1="30.2428" y2="58.3026" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" />
+        <line x1="22.1376" x2="15.4257" y1="33.8403" y2="33.8403" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" />
+        <line x1="23.5954" x2="13.4405" y1="40.2758" y2="40.2758" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" />
+        <line x1="21.6102" x2="11.4553" y1="46.7114" y2="46.7114" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" />
+        <line x1="19.625" x2="9.4701" y1="53.1469" y2="53.1469" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" />
+        <polyline fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" points="48.119 45.962 36.447 27.031 28.115 27.031" />
+        <path fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m53.2028,58.3026h6.6826v-3.8061h-.5164c-1.9375.0002-3.8388-.5245-5.5019-1.5185" />
+        <path fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m29.2434,22.9412l1.7632-6.88.0151-.07c.2801-1.3514,1.154-2.5048,2.3793-3.14,1.9853-.88,4.13.52,4.8041,3.14l1.8186,7.09,13.8743,22.58c1.3552,2.4993,3.919,4.1076,6.759,4.24h1.9706c1.1046,0,2,.8954,2,2v4.4018c0,1.1046-.8954,2-2,2h-2.7422" />
+        <path fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m21.7457,27.0308h-8.2518l2.8112-10.97.0152-.07c.2801-1.3514,1.154-2.5048,2.3793-3.14,1.9853-.88,4.13.52,4.8041,3.14l1.8186,7.09,13.8743,22.58c1.3552,2.4993,3.919,4.1076,6.759,4.24h1.9706c1.1046,0,2,.8954,2,2v4.4018c0,1.1046-.8954,2-2,2h-6.9044l-19.2761-31.2718Z" />
+      </g>
+    </SvgIcon>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './style.css';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    primary: { main: '#2e7d32' }
+  }
+});
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add custom PlaygroundIcon component
- show the icon in the toolbar next to the title
- switch color theme to green and use ThemeProvider
- remove redundant headings from ASR, Log and Settings tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a0c664e44832497403ed962ebe7d1