### PR TITLE
Add persistent error bar and storage failure indicator

### DIFF
--- a/src/errorBarStyle.test.js
+++ b/src/errorBarStyle.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+
+describe('error bar style', () => {
+  it('contains error-bar class', () => {
+    const css = fs.readFileSync('src/style.css', 'utf8');
+    expect(css.includes('.error-bar')).toBe(true);
+  });
+});

--- a/src/style.css
+++ b/src/style.css
@@ -4,3 +4,17 @@ table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
 th, td { border: 1px solid #ccc; padding: 0.25rem; }
 .insert { background-color: #dfd; }
 .delete { background-color: #fdd; text-decoration: line-through; }
+.error-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: #b71c1c;
+  color: #fff;
+  font-size: 0.8rem;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  z-index: 1201;
+}


### PR DESCRIPTION
## Summary
- report localStorage errors via global event
- show all errors in persistent bottom bar
- mark audio rows that failed to store
- style error bar
- test for error bar style

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a1a83add48324804c581fb8c8f90f