### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1357,7 +1357,14 @@ export default function App({ darkMode, setDarkMode }) {
         <Toolbar>
           <PlaygroundIcon sx={{ mr: 1 }} />
           <Typography variant="h6" sx={{ flexGrow: 1 }}>{t('appTitle')}</Typography>
-          <Tabs value={view} onChange={(e, v) => setView(v)} textColor="inherit" indicatorColor="secondary">
+          <Tabs
+            value={view}
+            onChange={(e, v) => setView(v)}
+            textColor="inherit"
+            indicatorColor="secondary"
+            variant="scrollable"
+            scrollButtons="auto"
+          >
             <Tab value="text" label={t('tabText')} />
             <Tab value="audio" label={t('tabAudio')} />
             <Tab value="asr" label={t('tabAsr')} />
@@ -1375,9 +1382,9 @@ export default function App({ darkMode, setDarkMode }) {
           )}
         </Toolbar>
       </AppBar>
-      <div style={{ paddingTop: '64px' }}>
+      <Box sx={{ pt: { xs: '56px', sm: '64px' } }}>
       {view === 'text' && (
-        <div style={{ padding: '1rem' }}>
+        <div className="content">
           <Typography variant="subtitle2">{t('selectedModels')}: {selectedTextModels.join(', ')}</Typography>
           <Select
             value={demoPrompt}
@@ -1422,7 +1429,7 @@ export default function App({ darkMode, setDarkMode }) {
         </div>
       )}
       {view === 'audio' && (
-        <div style={{ padding: '1rem' }}>
+        <div className="content">
           <Select
             value={demoInstruction}
             onChange={e => { setDemoInstruction(e.target.value); setTtsMetaPrompt(e.target.value); }}
@@ -1493,7 +1500,7 @@ export default function App({ darkMode, setDarkMode }) {
         </div>
       )}
       {view === 'asr' && (
-        <div style={{ padding: '1rem' }}>
+        <div className="content">
           <Typography variant="subtitle2">{t('selectedModels')}: {selectedAsrModels.join(', ')}</Typography>
           <Select
             value={demoPrompt}
@@ -1540,7 +1547,7 @@ export default function App({ darkMode, setDarkMode }) {
         </div>
       )}
       {view === 'models' && (
-        <div style={{ padding: '1rem' }}>
+        <div className="content">
           <FormControlLabel
             control={<Switch checked={showSelectedOnly} onChange={e => setShowSelectedOnly(e.target.checked)} />}
             label={t('showSelected')}
@@ -1556,7 +1563,7 @@ export default function App({ darkMode, setDarkMode }) {
         </div>
       )}
       {view === 'log' && (
-        <div style={{ padding: '1rem' }}>
+        <div className="content">
           <Divider sx={{ my: 2 }} />
           <ExportButtons rows={logRows} columns={logColumns} name="logs" t={t} />
           <PersistedGrid
@@ -1569,7 +1576,7 @@ export default function App({ darkMode, setDarkMode }) {
         </div>
       )}
       {view === 'config' && (
-        <div style={{ padding: '1rem' }}>
+        <div className="content">
           <Divider textAlign="left" sx={{ mb: 1 }}>{t('keysGroup')}</Divider>
           <TextField
             label={t('openaiKey')}
@@ -1634,7 +1641,7 @@ export default function App({ darkMode, setDarkMode }) {
           </Box>
         </div>
       )}
-      </div>
+      </Box>
       {errors.length > 0 && (
         <div className="error-bar">
           <span>{errors.join(' | ')}</span>

--- a/src/style.css
+++ b/src/style.css
@@ -2,6 +2,7 @@ body { font-family: sans-serif; margin: 0; }
 textarea { width: 100%; height: 6rem; }
 table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
 th, td { border: 1px solid #ccc; padding: 0.25rem; }
+.content { padding: 1rem; }
 .insert { background-color: #dfd; }
 .delete { background-color: #fdd; text-decoration: line-through; }
 .monospace { font-family: monospace; }
@@ -18,4 +19,10 @@ th, td { border: 1px solid #ccc; padding: 0.25rem; }
   align-items: center;
   justify-content: space-between;
   z-index: 1201;
+}
+
+@media (max-width: 600px) {
+  .content { padding: 0.5rem; }
+  table, th, td { font-size: 0.9rem; }
+  .error-bar { font-size: 0.75rem; padding: 3px 6px; }
 }


### PR DESCRIPTION
## Summary
- add `.content` class and mobile styles
- update tab bar to scroll on small screens
- adjust padding for the main container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686039daf71883248c4b9d32aee80622