### PR TITLE
Fix Mistral transcription uploads

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -710,6 +710,14 @@ export default function App({ darkMode, setDarkMode }) {
     return new Blob([arr], { type: mime });
   };
 
+  const mimeExtension = mime => {
+    if (/mpeg|mp3/.test(mime)) return 'mp3';
+    if (/ogg/.test(mime)) return 'ogg';
+    if (/wav/.test(mime)) return 'wav';
+    if (/webm/.test(mime)) return 'webm';
+    return 'dat';
+  };
+
   const audioDuration = url => new Promise(resolve => {
     const a = new Audio();
     a.addEventListener('loadedmetadata', () => resolve(a.duration || 0));
@@ -1060,7 +1068,7 @@ export default function App({ darkMode, setDarkMode }) {
         const orModel = openRouterMap[model].id;
         const form = new FormData();
         form.append('model', orModel);
-        form.append('file', blob, 'audio.webm');
+        form.append('file', blob, `audio.${mimeExtension(blob.type)}`);
         if (asrPrompt) form.append('prompt', expandRefs(asrPrompt, { texts, audios, textPrompt, ttsPrompt }));
         try {
           const url = 'https://openrouter.ai/api/v1/audio/transcriptions';
@@ -1084,7 +1092,7 @@ export default function App({ darkMode, setDarkMode }) {
       } else if (mistralModels.includes(model)) {
         const form = new FormData();
         form.append('model', model);
-        form.append('file', blob, 'audio.webm');
+        form.append('file', blob, `audio.${mimeExtension(blob.type)}`);
         if (asrPrompt) form.append('prompt', expandRefs(asrPrompt, { texts, audios, textPrompt, ttsPrompt }));
         try {
           const url = 'https://api.mistral.ai/v1/audio/transcriptions';
@@ -1106,7 +1114,7 @@ export default function App({ darkMode, setDarkMode }) {
       } else if (openAiModels.includes(model)) {
         const form = new FormData();
         form.append('model', model);
-        form.append('file', blob, 'audio.webm');
+        form.append('file', blob, `audio.${mimeExtension(blob.type)}`);
         if (asrPrompt) form.append('prompt', expandRefs(asrPrompt, { texts, audios, textPrompt, ttsPrompt }));
         try {
           const url = 'https://api.openai.com/v1/audio/transcriptions';

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -91,8 +91,8 @@ describe('App.jsx compilation', () => {
   });
   it('shows generate tooltips with models', () => {
     const code = fs.readFileSync('src/App.jsx', 'utf8');
-    expect(/Tooltip\s*\n\s*title={selectedTextModels.length/.test(code)).toBe(true);
-    expect(/Tooltip\s*\n\s*title={selectedTtsModels.length/.test(code)).toBe(true);
+    expect(/Tooltip\s*\n\s*title={selectedTextModels\.join/.test(code)).toBe(true);
+    expect(/Tooltip\s*\n\s*title={selectedTtsModels\.join/.test(code)).toBe(true);
   });
   it('shows models tab tooltip with selected models', () => {
     const code = fs.readFileSync('src/App.jsx', 'utf8');
@@ -108,6 +108,6 @@ describe('App.jsx compilation', () => {
   });
   it('shows ASR generate tooltip with models', () => {
     const code = fs.readFileSync('src/App.jsx', 'utf8');
-    expect(/Tooltip\s*\n\s*title={selectedAsrModels.length/.test(code)).toBe(true);
+    expect(/Tooltip\s*\n\s*title={selectedAsrModels\.join/.test(code)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add `mimeExtension` helper to derive file extension from MIME type
- use actual audio file extensions when uploading to Mistral and other ASR APIs
- update tests checking tooltips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a9d8df2d083248479c198e8f4735c