### PR TITLE
Fix WER reference text for TTS

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1028,13 +1028,13 @@ export default function App({ darkMode, setDarkMode }) {
     const idx = texts.length;
     const timestamp = new Date().toISOString();
     const fullPrompt = `${ttsMetaPrompt} ${ttsPrompt}`;
-    setTexts([...texts, { provider: 'tts', text: fullPrompt }]);
+    setTexts([...texts, { provider: 'tts', text: ttsPrompt, instructions: ttsMetaPrompt }]);
     for (const model of selectedTtsModels) {
       const cost = ttsModels.find(m => m.id === model)?.cost || '';
       let rowIndex;
       setAudios(a => {
         rowIndex = a.length;
-        return [...a, { index: idx, provider: model, prompt: fullPrompt, timestamp, pending: true }];
+        return [...a, { index: idx, provider: model, prompt: ttsPrompt, instructions: ttsMetaPrompt, timestamp, pending: true }];
       });
       if (openRouterMap[model]) {
         const orModel = openRouterMap[model].id;

--- a/src/resultUtils.test.js
+++ b/src/resultUtils.test.js
@@ -27,4 +27,14 @@ describe('transcriptsToRows', () => {
     expect(rows[0].pending).toBe(true);
     expect(rows[0].wer).toBe('');
   });
+
+  it('ignores TTS instructions when computing WER', () => {
+    const texts = [{ text: 'hello there', instructions: 'fast', provider: 'tts' }];
+    const audios = [{ index: 0, provider: 'tts' }];
+    const transcripts = [
+      { aIndex: 0, provider: 'mock', text: 'hello there' }
+    ];
+    const rows = transcriptsToRows(transcripts, audios, texts);
+    expect(rows[0].wer).toBe('0.00');
+  });
 });


### PR DESCRIPTION
## Summary
- store TTS instructions separately from the spoken text
- ensure result calculation ignores instructions when computing WER
- add test covering this case

## Testing
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c1d74e2f88324a4104337d149c060