### PR TITLE
Animate pending rows

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -161,6 +161,7 @@ function PersistedGrid({ storageKey, t, initialCols = {}, initialSort = [], ...p
       <DataGrid
         autoHeight
         getRowHeight={() => 'auto'}
+        getRowClassName={params => params.row.pending ? 'pending-row' : ''}
         disableRowSelectionOnClick
         sx={{ '& .MuiDataGrid-cell': {
           whiteSpace: 'normal',
@@ -274,7 +275,7 @@ function renderHtmlCell(params, tab) {
 
 function renderProgressCell(params, tab) {
   if (params.row.pending && (params.value === undefined || params.value === '')) {
-    return <DotSpinner className="dot-spinner" />;
+    return '';
   }
   if (params.row.error) {
     return <span style={{color:'red'}}>{params.row.error}</span>;
@@ -284,7 +285,7 @@ function renderProgressCell(params, tab) {
 
 function renderHtmlProgressCell(params, tab) {
   if (params.row.pending && !params.value) {
-    return <DotSpinner className="dot-spinner" />;
+    return '';
   }
   if (params.row.error) {
     return <span style={{color:'red'}}>{params.row.error}</span>;
@@ -1270,7 +1271,7 @@ export default function App({ darkMode, setDarkMode }) {
 
   const audioRows = audios.map((a, i) => ({ id: i, ...a, _index: i }));
   const renderAudioCell = p => (
-    p.row.pending ? <DotSpinner className="dot-spinner" /> : (
+    p.row.pending ? '' : (
       <div>
         {p.row.error && <div style={{color:'red'}}>{p.row.error}</div>}
         {p.row.url && <audio controls src={p.row.url}></audio>}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -142,4 +142,9 @@ describe('App.jsx compilation', () => {
     expect(code.includes("type: 'number'")).toBe(true);
     expect(code.includes('1e6')).toBe(true);
   });
+  it('adds pending-row class to pending rows', () => {
+    const code = fs.readFileSync('src/App.jsx', 'utf8');
+    expect(code.includes('getRowClassName')).toBe(true);
+    expect(code.includes('pending-row')).toBe(true);
+  });
 });

--- a/src/errorBarStyle.test.js
+++ b/src/errorBarStyle.test.js
@@ -10,4 +10,9 @@ describe('error bar style', () => {
     const css = fs.readFileSync('src/style.css', 'utf8');
     expect(css.includes('.dot-spinner')).toBe(true);
   });
+  it('contains pending-row animation', () => {
+    const css = fs.readFileSync('src/style.css', 'utf8');
+    expect(css.includes('.pending-row')).toBe(true);
+    expect(css.includes('@keyframes rowPending')).toBe(true);
+  });
 });

--- a/src/style.css
+++ b/src/style.css
@@ -49,3 +49,13 @@ th, td { border: 1px solid #ccc; padding: 0.25rem; }
   color:var(--mui-palette-primary-main,#2da44e);
   font-size:1.5rem
 }
+
+@keyframes rowPending {
+  0% { background-color: rgba(45,164,78,0.2); }
+  50% { background-color: rgba(45,164,78,0.05); }
+  100% { background-color: rgba(45,164,78,0.2); }
+}
+
+.pending-row {
+  animation: rowPending 1s linear infinite;
+}


### PR DESCRIPTION
## Summary
- animate table row backgrounds when rows are still pending
- remove DotSpinner from table cell rendering
- update tests for pending row style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d64dd78b08324ad84cf1a77c33b39