### PR TITLE
Improve button styling

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -34,10 +34,38 @@ function Root() {
           },
           MuiButton: {
             styleOverrides: {
-              root: {
+              root: ({ theme }) => ({
                 borderRadius: 6,
-                textTransform: 'none'
-              }
+                textTransform: 'none',
+                minWidth: 44,
+                minHeight: 44,
+                transition:
+                  'background-color 150ms, box-shadow 150ms, transform 100ms',
+                boxShadow:
+                  theme.palette.mode === 'dark'
+                    ? '0 1px 2px rgba(255,255,255,0.1)'
+                    : '0 1px 2px rgba(0,0,0,0.1)',
+                '&:hover': {
+                  boxShadow:
+                    theme.palette.mode === 'dark'
+                      ? '0 2px 6px rgba(255,255,255,0.2)'
+                      : '0 2px 6px rgba(0,0,0,0.2)'
+                },
+                '&:active': {
+                  transform: 'scale(0.97)',
+                  boxShadow:
+                    theme.palette.mode === 'dark'
+                      ? '0 1px 2px rgba(255,255,255,0.2)'
+                      : '0 1px 2px rgba(0,0,0,0.2)'
+                },
+                '&.Mui-focusVisible': {
+                  boxShadow: `0 0 0 2px ${theme.palette.primary.main}`
+                },
+                '&.Mui-disabled': {
+                  opacity: 0.5,
+                  boxShadow: 'none'
+                }
+              })
             }
           }
         }

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+
+describe('main.jsx theme', () => {
+  it('applies button state styles', () => {
+    const code = fs.readFileSync('src/main.jsx', 'utf8');
+    expect(code.includes('minWidth: 44')).toBe(true);
+    expect(code.includes('minHeight: 44')).toBe(true);
+    expect(code.includes('transform 100ms')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- update MUI button theme with hover/focus/active styles and larger touch target
- add regression test for button style overrides

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886b56ffd748324804f320c7459a078