### PR TITLE
Make prompts resizable

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -347,6 +347,30 @@ function ExportButtons({ rows, columns, name, t, children }) {
   );
 }
 
+function ResizableTextField({ heightKey, minRows, inputRef, onMouseUp, sx = {}, ...props }) {
+  const [height, setHeight] = useStoredState(heightKey, 0);
+  const ref = React.useRef();
+  const combinedRef = node => {
+    ref.current = node;
+    if (typeof inputRef === 'function') inputRef(node);
+    else if (inputRef) inputRef.current = node;
+  };
+  const handleMouseUp = e => {
+    if (ref.current) setHeight(ref.current.clientHeight);
+    if (onMouseUp) onMouseUp(e);
+  };
+  return (
+    <TextField
+      {...props}
+      multiline
+      minRows={minRows}
+      inputRef={combinedRef}
+      onMouseUp={handleMouseUp}
+      sx={{ '& textarea': { resize: 'vertical', ...(height ? { height } : {}) }, ...sx }}
+    />
+  );
+}
+
 const translations = {
   en: {
     appTitle: 'Speech Playground',
@@ -1531,10 +1555,10 @@ export default function App({ darkMode, setDarkMode }) {
       {view === 'text' && (
         <div className="content">
           <Tooltip title={expandRefs(textPrompt, { texts, audios, textPrompt, ttsPrompt })} placement="top">
-            <TextField
+            <ResizableTextField
+              heightKey="textPromptHeight"
               label={t('promptForModels')}
-              multiline
-              rows={3}
+              minRows={3}
               value={textPrompt}
               onChange={e => setTextPrompt(e.target.value)}
               fullWidth
@@ -1588,10 +1612,10 @@ export default function App({ darkMode, setDarkMode }) {
       {view === 'audio' && (
         <div className="content">
           <Tooltip title={expandRefs(ttsMetaPrompt, { texts, audios, textPrompt, ttsPrompt })} placement="top">
-            <TextField
+            <ResizableTextField
+              heightKey="ttsMetaPromptHeight"
               label={t('metaPromptLabel')}
-              multiline
-              rows={2}
+              minRows={2}
               value={ttsMetaPrompt}
               onChange={e => setTtsMetaPrompt(e.target.value)}
               fullWidth
@@ -1620,10 +1644,10 @@ export default function App({ darkMode, setDarkMode }) {
             ))}
           </Menu>
           <Tooltip title={expandRefs(ttsPrompt, { texts, audios, textPrompt, ttsPrompt })} placement="top">
-            <TextField
+            <ResizableTextField
+              heightKey="ttsPromptHeight"
               label={t('ttsPromptLabel')}
-              multiline
-              rows={4}
+              minRows={4}
               value={ttsPrompt}
               InputProps={{
                 readOnly: true,
@@ -1675,10 +1699,10 @@ export default function App({ darkMode, setDarkMode }) {
       {view === 'asr' && (
         <div className="content">
           <Tooltip title={expandRefs(asrPrompt, { texts, audios, textPrompt, ttsPrompt })} placement="top">
-            <TextField
+            <ResizableTextField
+              heightKey="asrPromptHeight"
               label={t('asrPromptLabel')}
-              multiline
-              rows={3}
+              minRows={3}
               value={asrPrompt}
               onChange={e => setAsrPrompt(e.target.value)}
               fullWidth

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -142,6 +142,13 @@ describe('App.jsx compilation', () => {
     expect(code.includes("type: 'number'")).toBe(true);
     expect(code.includes('1e6')).toBe(true);
   });
+  it('persists prompt textarea heights', () => {
+    const code = fs.readFileSync('src/App.jsx', 'utf8');
+    expect(code.includes('textPromptHeight')).toBe(true);
+    expect(code.includes('ttsMetaPromptHeight')).toBe(true);
+    expect(code.includes('ttsPromptHeight')).toBe(true);
+    expect(code.includes('asrPromptHeight')).toBe(true);
+  });
   it('adds pending-row class to pending rows', () => {
     const code = fs.readFileSync('src/App.jsx', 'utf8');
     expect(code.includes('getRowClassName')).toBe(true);

--- a/src/style.css
+++ b/src/style.css
@@ -5,7 +5,11 @@ body {
   background-color: var(--mui-palette-background-default, #f6f8fa);
   color: var(--mui-palette-text-primary, #24292e);
 }
-textarea { width: 100%; height: 6rem; }
+textarea {
+  width: 100%;
+  min-height: 6rem;
+  resize: vertical;
+}
 table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
 th, td { border: 1px solid #ccc; padding: 0.25rem; }
 .content {

--- a/src/textareaResize.test.js
+++ b/src/textareaResize.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+
+describe('textarea resize style', () => {
+  it('allows vertical resize', () => {
+    const css = fs.readFileSync('src/style.css', 'utf8');
+    expect(css.includes('resize: vertical')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- allow resizing Text, Audio and ASR prompts
- store prompt sizes in local storage
- ensure textareas are vertically resizable in CSS
- test textarea resize style and persistence keys

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887bc2dc3888324915b0261858c48fc