### PR TITLE
fix: allow text selection without dialog

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -155,6 +155,8 @@ function PersistedGrid({ storageKey, t, initialCols = {}, initialSort = [], ...p
   const handleCellClick = (params, event) => {
     if (params.field === 'actions') return;
     if (event.target.closest('input[type="checkbox"]')) return;
+    const sel = window.getSelection?.();
+    if (sel && !sel.isCollapsed) return;
     setPreviewRow(params.row);
   };
   return (

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -109,6 +109,11 @@ describe('App.jsx compilation', () => {
     const code = fs.readFileSync('src/App.jsx', 'utf8');
     expect(code.includes("closest('input[type=\"checkbox\"]')")).toBe(true);
   });
+  it('ignores text selection clicks', () => {
+    const code = fs.readFileSync('src/App.jsx', 'utf8');
+    expect(code.includes('getSelection')).toBe(true);
+    expect(code.includes('isCollapsed')).toBe(true);
+  });
   it('includes generateTranscript translation', () => {
     const code = fs.readFileSync('src/App.jsx', 'utf8');
     expect(code.includes('generateTranscript')).toBe(true);


### PR DESCRIPTION
## Summary
- allow selecting text in table cells without triggering the preview dialog
- test that selection is ignored when clicking cells

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689289d482908324a0557ce01e43953e